### PR TITLE
Upgrade zCord

### DIFF
--- a/gyro.lock
+++ b/gyro.lock
@@ -1,4 +1,4 @@
-github fengb zCord master src/main.zig 8bad0c2f286ac74f794c54493ac3db6ce5cba35c
-pkg default truemedian hzzp 0.0.2
+github fengb zCord master src/main.zig ba864c8c1b8d22cfa874042302dc03f350242e80
+pkg default truemedian hzzp 0.0.3
 pkg default truemedian wz 0.0.1
 pkg default alexnask iguanaTLS 0.0.1

--- a/src/main.zig
+++ b/src/main.zig
@@ -211,11 +211,11 @@ pub fn main() !void {
             );
             defer req.deinit();
 
-            if (req.expectSuccessStatus()) |_| {
+            if (req.response_code.?.group() == .success) {
                 try req.completeHeaders();
                 return;
-            } else |err| switch (err) {
-                error.TooManyRequests => {
+            } else switch (req.response_code.?) {
+                .client_too_many_requests => {
                     try req.completeHeaders();
 
                     var stream = zCord.json.stream(req.client.reader());
@@ -232,7 +232,7 @@ pub fn main() !void {
                     // var buf: [1024]u8 = undefined;
                     // const n = try req.client.reader().readAll(&buf);
                     // std.debug.print("toggle error: {s}\n", .{buf[0..n]});
-                    return err;
+                    return error.UnknownResponse;
                 },
             }
         }


### PR DESCRIPTION
zCord was ignoring an *app* response of "invalid session", but the websocket *gateway* continued to respond to heartbeats and never asked to reconnect.

I've changed the behavior to force a reconnect.